### PR TITLE
Cache resolved context-factory chain on context-aware schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Next release
 
+### Changed
+- Context-aware schemas (`ContextSchema<T, TContext, TSchema>`) now cache the resolved context-factory chain on the schema instance after the first `GetContextFactories()` call instead of re-walking conditionals/type-assertions and re-yielding on every `ValidateAsync`. `ContextFactoryResolver.ResolveAsync` also skips re-copying an already-materialized list. No public API or behavior change — schemas are immutable after construction (RFC 007), so caching is safe.
+
 ## 0.1.17
 
 ### Added

--- a/src/Zeta/Core/ContextFactoryResolver.cs
+++ b/src/Zeta/Core/ContextFactoryResolver.cs
@@ -8,7 +8,8 @@ internal static class ContextFactoryResolver
         IServiceProvider serviceProvider,
         CancellationToken ct)
     {
-        var factoryList = factories.ToList();
+        var factoryList = factories as IReadOnlyList<Func<T, IServiceProvider, CancellationToken, ValueTask<TContext>>>
+            ?? factories.ToList();
         if (factoryList.Count == 0)
         {
             throw new InvalidOperationException(

--- a/src/Zeta/Core/ContextSchema.cs
+++ b/src/Zeta/Core/ContextSchema.cs
@@ -97,6 +97,8 @@ public abstract class ContextSchema<T, TContext, TSchema> : IContextSchema<T, TC
 
     private readonly IReadOnlyList<ISchemaConditional<T, TContext>>? _conditionals;
 
+    private Func<T, IServiceProvider, CancellationToken, ValueTask<TContext>>[]? _materializedFactories;
+
     protected ContextSchema() : this(new ContextRuleEngine<T, TContext>(), false, null, null)
     {
     }
@@ -186,7 +188,11 @@ public abstract class ContextSchema<T, TContext, TSchema> : IContextSchema<T, TC
 
     IEnumerable<Func<T, IServiceProvider, CancellationToken, ValueTask<TContext>>> ISchema<T, TContext>.GetContextFactories()
     {
-        return GetContextFactoriesCore();
+        // The schema instance is immutable once constructed (see RFC 007), so the resolved
+        // factory chain never changes after the first call. A benign race that recomputes
+        // the same array is fine — cheaper than re-walking conditionals/type-assertions on
+        // every ValidateAsync call.
+        return _materializedFactories ??= GetContextFactoriesCore().ToArray();
     }
 
     protected virtual IEnumerable<Func<T, IServiceProvider, CancellationToken, ValueTask<TContext>>> GetContextFactoriesCore()


### PR DESCRIPTION
GetContextFactories() previously re-walked the conditional/type-assertion
tree and re-yielded on every ValidateAsync call for context-aware schemas.
Schemas are immutable after construction (RFC 007), so this is now
memoized on the instance after the first call, mirroring the existing
Materialize() pattern used by the rule engines. ContextFactoryResolver
also avoids copying the list again when it's already materialized.